### PR TITLE
changed axi read error check to M_AXI_RRESP(1) = '1'

### DIFF
--- a/spi_axim/spi_axi_master.vhd
+++ b/spi_axim/spi_axi_master.vhd
@@ -167,7 +167,7 @@ begin
 	          mst_exec_state <= BUS_DONE;
 						bus_data_o     <= M_AXI_RDATA;
 						M_AXI_RREADY   <= '0';
-					elsif M_AXI_RRESP(1) = '0' then
+					elsif M_AXI_RRESP(1) = '1' then
 						mst_exec_state <= BUS_DONE;
 						bus_data_o     <= (others => '0');
 						M_AXI_RREADY   <= '0';


### PR DESCRIPTION
with a slow axi slave, when checking M_AXI_RRESP(1) = '0', the state machine is getting trash in the axi read.