### PR TITLE
byte addressing in auto increment

### DIFF
--- a/spi_axim/spi_control_mq.vhd
+++ b/spi_axim/spi_control_mq.vhd
@@ -538,7 +538,7 @@ begin
 
           when inc_addr_st   =>
             spi_mq <= next_state(command_v, aux_cnt, spi_busy_i, spi_mq);
-            addr_v := addr_v + 1;
+            addr_v := addr_v + data_word_size;
 
           when others   =>
             spi_txen_o   <=   '0';


### PR DESCRIPTION
maybe also rework this line:

addr_v     := buffer_v(addr_v'range);

to guarantee addr_v is byte oriented?