### PR TITLE
oversampled clock mode bug fix

### DIFF
--- a/spi_axim/spi_slave.vhd
+++ b/spi_axim/spi_slave.vhd
@@ -101,7 +101,8 @@ begin
     spck_s        <= mclk_i;
     spi_busy_o    <= busy_s;
     spi_rxdata_o  <= rxdata_s;
-    spi_rxen_o    <= rx_en;
+    det_rxen_u : det_up
+      port map ('0',mclk_i,rxdata_en,spi_rxen_o);
 
     sync_mosi_u : sync_r
       generic map (2)
@@ -153,10 +154,10 @@ end generate;
       if spck_en = '1' then
         if rx_en = '1' then
           input_sr <= "0000000";
-          rxdata_s <= input_sr(6 downto 0) & mosi_i;
+          rxdata_s <= input_sr(6 downto 0) & mosi_s;
           rxdata_en <= '1';
         else
-          input_sr <= input_sr(5 downto 0) & mosi_i;
+          input_sr <= input_sr(5 downto 0) & mosi_s;
           rxdata_en <= '0';
         end if;
       end if;


### PR DESCRIPTION
when oversampled clock is enabled, the spi_slave reads data from mosi_i instead of the sync'd mosi_s
And the signal spi_rx_en_o is a bit strange, please check if the change i made makes sense.