### PR TITLE
fast and slow read multiple words

### DIFF
--- a/spi_axim/spi_control_mq.vhd
+++ b/spi_axim/spi_control_mq.vhd
@@ -407,7 +407,9 @@ begin
             end if;
 
           when wait4spi_st =>
-            if spi_rxen_i = '1' then
+            if spi_busy_i = '0' then -- If SPI bus is deactivated
+              spi_mq   <= next_state(command_v, aux_cnt, spi_busy_i, spi_mq);
+            elsif spi_rxen_i = '1' then
               aux_cnt      := aux_cnt + 1;
               buffer_v     := buffer_v sll 8;
               buffer_v     := set_slice(buffer_v, spi_rxdata_i, 0);

--- a/spi_axim/spi_control_mq.vhd
+++ b/spi_axim/spi_control_mq.vhd
@@ -432,7 +432,7 @@ begin
                 spi_txen_o <= '0';
                 if bus_done_i = '1' then
                   bus_read_o <= '0';
-                  buffer_v   := set_slice(buffer_v, bus_data_i, buffer_size-1);
+                  buffer_v   := set_slice(buffer_v, bus_data_i, 0);
                 end if;
                 if spi_rxen_i = '1' then
                   spi_txen_o   <= '1';
@@ -447,7 +447,7 @@ begin
                 if bus_done_i = '1' then
                   bus_read_o   <= '0';
                   spi_mq       <= next_state(command_v, aux_cnt, spi_busy_i, spi_mq);
-                  buffer_v     := set_slice(buffer_v, bus_data_i, buffer_size-1);
+                  buffer_v     := set_slice(buffer_v, bus_data_i, 0);
                   spi_txen_o   <= '1';
                   spi_txdata_o <= get_slice(buffer_v,8,buffer_size-1);
                 end if;

--- a/spi_axim/spi_control_mq.vhd
+++ b/spi_axim/spi_control_mq.vhd
@@ -242,7 +242,7 @@ architecture behavioral of spi_control_mq is
               tmp := act_st;
             end if;
           when READ_c =>
-            if aux_cnt = data_word_size-1 then
+            if aux_cnt = data_word_size then
               tmp := inc_addr_st;
             end if;
           when FAST_READ_c =>


### PR DESCRIPTION
there are basically 4 changes here, please take a look and check if they make sense
1. the state machine was staying in wait4spi_st even when the CS was deactivated
2. when reading from the axi bus, the buffer_v was not being correctly filled (set_slice parameter was wrong)
3. when doing fast_read, during the act_st, the axi was being read many times, depending on the speed of the axi slave, until the spi_rxen_i came
4. when reading multiple words with the slow read, the second time going to act_st was done too soon, missing the last spi word