### PR TITLE
slow read fix

### DIFF
--- a/spi_axim/spi_control_mq.vhd
+++ b/spi_axim/spi_control_mq.vhd
@@ -229,7 +229,7 @@ architecture behavioral of spi_control_mq is
               tmp := act_st;
             end if;
           when READ_c =>
-            if aux_cnt = data_word_size-1 then
+            if aux_cnt = data_word_size then
               tmp := act_st;
             end if;
           when FAST_READ_c =>


### PR DESCRIPTION
apparently this is still needed.
My tb reads the first 3 bytes correctly, then the 4th byte is "skipped", so the master gets the byte 5 instead of 4
This happens because when in the act_st, the spi_txdata_o is set before the spi_slave block can get the previous value.
My axi slave takes only 1 clk to set the rvalid