### PR TITLE
fast read fix

### DIFF
--- a/spi_axim/spi_control_mq.vhd
+++ b/spi_axim/spi_control_mq.vhd
@@ -386,10 +386,10 @@ begin
               spi_mq   <= next_state(command_v, aux_cnt, spi_busy_i, spi_mq);
             elsif spi_rxen_i = '1' then
               aux_cnt      := aux_cnt + 1;
-              buffer_v     := buffer_v sll 8;
-              buffer_v     := set_slice(buffer_v, spi_rxdata_i, 0);
               spi_mq       <= next_state(command_v, aux_cnt, spi_busy_i, spi_mq);
               spi_txdata_o <= get_slice(buffer_v,8,buffer_size-1);
+              buffer_v     := buffer_v sll 8;
+              buffer_v     := set_slice(buffer_v, spi_rxdata_i, 0);
               if aux_cnt = addr_word_size then
                 aux_cnt := 0;
               end if;
@@ -415,6 +415,7 @@ begin
                   spi_mq       <= next_state(command_v, aux_cnt, spi_busy_i, spi_mq);
                   buffer_v     := set_slice(buffer_v, bus_data_i, 0);
                   spi_txdata_o <= get_slice(buffer_v,8,buffer_size-1);
+                  buffer_v     := buffer_v sll 8;
                 end if;
 
               when WRITE_c        =>
@@ -442,11 +443,13 @@ begin
               when RDID_c        =>
                 buffer_v     := did_i;
                 spi_txdata_o <= get_slice(buffer_v,8,buffer_size-1);
+                buffer_v     := buffer_v sll 8;
                 spi_mq       <= next_state(command_v, aux_cnt, spi_busy_i, spi_mq);
 
               when RUID_c        =>
                 buffer_v     := uid_i;
                 spi_txdata_o <= get_slice(buffer_v,8,buffer_size-1);
+                buffer_v     := buffer_v sll 8;
                 spi_mq       <= next_state(command_v, aux_cnt, spi_busy_i, spi_mq);
 
               when WRSN_c        =>
@@ -462,6 +465,7 @@ begin
                   buffer_v     := serial_num_i;
                 end if;
                 spi_txdata_o <= get_slice(buffer_v,8,buffer_size-1);
+                buffer_v     := buffer_v sll 8;
                 spi_mq       <= next_state(command_v, aux_cnt, spi_busy_i, spi_mq);
 
               when DPD_c         =>


### PR DESCRIPTION
this is a bit more annoying.
In the slow read, the data is output already in the act_st, then in the wait4spi_st it shifts the buffer_v and then outputs the next byte.
But in the fast read, the first byte is "ignored", as it is not output in the act_st (i understand why), and then the buffer_v is shifted (throwing the fst byte away).
My solution was to shift the buffer_v always after the byte is output. I dont think it is beautiful, it was just fast and easy to show where it was failing in my tb.